### PR TITLE
Refactor: abstract FHIR structures into separate yaml files

### DIFF
--- a/specification/components/schemas/CreateReferralAndSendForTriageParameters.yaml
+++ b/specification/components/schemas/CreateReferralAndSendForTriageParameters.yaml
@@ -11,16 +11,13 @@ properties:
     example: 'Parameters'
   meta:
     type: object
-    required: 
+    required:
       - profile
     properties:
       profile:
         type: array
         items:
-          type: string
-          enum:
-            - "https://fhir.nhs.uk/STU3/StructureDefinition/eRS-CreateReferralAndSendForTriage-Parameters-1"
-          example: "https://fhir.nhs.uk/STU3/StructureDefinition/eRS-CreateReferralAndSendForTriage-Parameters-1"
+          $ref: 'fhir/structures/eRS-CreateReferralAndSendForTriage-Parameters-1.yaml'
         minItems: 1
         maxItems: 1
   parameter:
@@ -44,7 +41,7 @@ properties:
               example: 'shortlist'
             resource:
               $ref: 'ShortlistList.yaml'
-        - title: | 
+        - title: |
             Parameter to supply the intention to add referral letter flag.
             When sending for triage, a referral letter is always required, therefore the only acceptable value is NEED_TO_ADD_LATER.
           type: object

--- a/specification/components/schemas/CreateReferralParameters.yaml
+++ b/specification/components/schemas/CreateReferralParameters.yaml
@@ -11,16 +11,13 @@ properties:
     example: 'Parameters'
   meta:
     type: object
-    required: 
+    required:
       - profile
     properties:
       profile:
         type: array
         items:
-          type: string
-          enum:
-            - "https://fhir.nhs.uk/STU3/StructureDefinition/eRS-CreateReferral-Parameters-1"
-          example: "https://fhir.nhs.uk/STU3/StructureDefinition/eRS-CreateReferral-Parameters-1"
+          $ref: 'fhir/structures/eRS-CreateReferral-Parameters-1.yaml'
         minItems: 1
         maxItems: 1
   parameter:

--- a/specification/components/schemas/FetchServicesList.yaml
+++ b/specification/components/schemas/FetchServicesList.yaml
@@ -9,16 +9,13 @@ required:
 properties:
   meta:
     type: object
-    required: 
+    required:
       - profile
     properties:
       profile:
         type: array
         items:
-          type: string
-          enum:
-            - 'https://fhir.nhs.uk/STU3/StructureDefinition/eRS-FetchServices-List-1'
-          example: 'https://fhir.nhs.uk/STU3/StructureDefinition/eRS-FetchServices-List-1'
+          $ref: 'fhir/structures/eRS-FetchServices-List-1.yaml'
   resourceType:
     type: string
     enum:
@@ -74,8 +71,8 @@ properties:
       title: Singular entry with service details
       type: object
       required:
-       - item
-       - extension
+        - item
+        - extension
       properties:
         extension:
           title: Extension to supply search specific details for a service
@@ -157,8 +154,8 @@ properties:
                               items:
                                 type: object
                                 required:
-                                 - system
-                                 - code 
+                                  - system
+                                  - code
                                 properties:
                                   system:
                                     type: string
@@ -174,10 +171,7 @@ properties:
                 minItems: 2
                 maxItems: 3
               url:
-                type: string
-                enum:
-                  - https://fhir.nhs.uk/STU3/StructureDefinition/Extension-eRS-ServiceSearch-ListItem-1
-                example: 'https://fhir.nhs.uk/STU3/StructureDefinition/Extension-eRS-ServiceSearch-ListItem-1'
+                $ref: 'fhir/structures/Extension-eRS-ServiceSearch-ListItem-1.yaml'
         item:
           type: object
           required:

--- a/specification/components/schemas/OperationOutcome.yaml
+++ b/specification/components/schemas/OperationOutcome.yaml
@@ -15,10 +15,7 @@ properties:
       profile:
         type: array
         items:
-          type: string
-          enum:
-            - 'https://fhir.nhs.uk/STU3/StructureDefinition/eRS-OperationOutcome-1'
-          example: 'https://fhir.nhs.uk/STU3/StructureDefinition/eRS-OperationOutcome-1'
+          $ref: 'fhir/structures/eRS-OperationOutcome-1.yaml'
         minItems: 1
         maxItems: 1
   issue:

--- a/specification/components/schemas/PatientServiceSearchParameters.yaml
+++ b/specification/components/schemas/PatientServiceSearchParameters.yaml
@@ -13,10 +13,7 @@ properties:
       profile:
         type: array
         items:
-          type: string
-          enum:
-            - 'https://fhir.nhs.uk/STU3/StructureDefinition/eRS-PatientServiceSearch-Parameters-1'
-          example: 'https://fhir.nhs.uk/STU3/StructureDefinition/eRS-PatientServiceSearch-Parameters-1'
+          $ref: 'fhir/structures/eRS-PatientServiceSearch-Parameters-1.yaml'
   resourceType:
     type: string
     enum:

--- a/specification/components/schemas/ReferralRequest.yaml
+++ b/specification/components/schemas/ReferralRequest.yaml
@@ -21,10 +21,7 @@ properties:
       profile:
         type: array
         items:
-          type: string
-          enum:
-            - 'https://fhir.nhs.uk/STU3/StructureDefinition/eRS-ReferralRequest-1'
-          example: 'https://fhir.nhs.uk/STU3/StructureDefinition/eRS-ReferralRequest-1'
+          $ref: 'fhir/structures/eRS-ReferralRequest-1.yaml'
       versionId:
         type: string
         example: '3'
@@ -68,9 +65,9 @@ properties:
     nullable: true
     items:
       type: object
-      required: 
+      required:
         - reference
       properties:
         reference:
-          type: string 
+          type: string
           example: '#DocumentReference-70000'

--- a/specification/components/schemas/SearchCriteriaParameters.yaml
+++ b/specification/components/schemas/SearchCriteriaParameters.yaml
@@ -17,10 +17,7 @@ properties:
       profile:
         type: array
         items:
-          type: string
-          enum:
-            - 'https://fhir.nhs.uk/STU3/StructureDefinition/eRS-ServiceSearchCriteria-Parameters-1'
-          example: 'https://fhir.nhs.uk/STU3/StructureDefinition/eRS-ServiceSearchCriteria-Parameters-1'
+          $ref: 'fhir/structures/eRS-ServiceSearchCriteria-Parameters-1.yaml'
   resourceType:
     type: string
     enum:

--- a/specification/components/schemas/ShortlistList.yaml
+++ b/specification/components/schemas/ShortlistList.yaml
@@ -7,16 +7,13 @@ required:
 properties:
   meta:
     type: object
-    required: 
+    required:
       - profile
     properties:
       profile:
         type: array
         items:
-          type: string
-          enum:
-            - 'https://fhir.nhs.uk/STU3/StructureDefinition/eRS-Shortlist-List-1'
-          example: 'https://fhir.nhs.uk/STU3/StructureDefinition/eRS-Shortlist-List-1'
+          $ref: 'fhir/structures/eRS-Shortlist-List-1.yaml'
   contained:
     type: array
     items:
@@ -32,7 +29,7 @@ properties:
       title: Singular entry with service details
       type: object
       required:
-       - item
+        - item
       properties:
         item:
           type: object

--- a/specification/components/schemas/extensions/EffectiveFromDateExtension.yaml
+++ b/specification/components/schemas/extensions/EffectiveFromDateExtension.yaml
@@ -6,10 +6,7 @@ required:
   - valueDate
 properties:
   url:
-    type: string
-    enum:
-      - 'https://fhir.nhs.uk/STU3/StructureDefinition/Extension-eRS-EffectivefromDate-1'
-    example: 'https://fhir.nhs.uk/STU3/StructureDefinition/Extension-eRS-EffectivefromDate-1'
+    $ref: '../fhir/structures/Extension-eRS-EffectivefromDate-1.yaml'
   valueDate:
     type: string
     format: date

--- a/specification/components/schemas/extensions/EffectiveToDateExtension.yaml
+++ b/specification/components/schemas/extensions/EffectiveToDateExtension.yaml
@@ -6,10 +6,7 @@ required:
   - valueDate
 properties:
   url:
-    type: string
-    enum:
-      - 'https://fhir.nhs.uk/STU3/StructureDefinition/Extension-eRS-EffectivetoDate-1'
-    example: 'https://fhir.nhs.uk/STU3/StructureDefinition/Extension-eRS-EffectivetoDate-1'
+    $ref: '../fhir/structures/Extension-eRS-EffectivetoDate-1.yaml'
   valueDate:
     type: string
     format: date

--- a/specification/components/schemas/extensions/ReferralAppointmentExtension.yaml
+++ b/specification/components/schemas/extensions/ReferralAppointmentExtension.yaml
@@ -5,16 +5,12 @@ required:
   - valueReference
 properties:
   url:
-    type: string
-    enum:
-      - 'https://fhir.nhs.uk/STU3/StructureDefinition/Extension-eRS-Appointment-1'
-    example: 'https://fhir.nhs.uk/STU3/StructureDefinition/Extension-eRS-Appointment-1'
+    $ref: '../fhir/structures/Extension-eRS-Appointment-1.yaml'
   valueReference:
     type: object
-    required: 
+    required:
       - reference
     properties:
       reference:
         type: string
         example: '#appointment'
-

--- a/specification/components/schemas/extensions/ReferralCommissioningOrganisationExtension.yaml
+++ b/specification/components/schemas/extensions/ReferralCommissioningOrganisationExtension.yaml
@@ -5,10 +5,7 @@ required:
   - valueIdentifier
 properties:
   url:
-    type: string
-    enum:
-      - 'https://fhir.nhs.uk/STU3/StructureDefinition/Extension-eRS-Commissioning-Rule-Org-1'
-    example: 'https://fhir.nhs.uk/STU3/StructureDefinition/Extension-eRS-Commissioning-Rule-Org-1'
+    $ref: '../fhir/structures/Extension-eRS-Commissioning-Rule-Org-1.yaml'
   valueIdentifier:
     type: object
     additionalProperties: false

--- a/specification/components/schemas/extensions/ReferralPriorityExtension.yaml
+++ b/specification/components/schemas/extensions/ReferralPriorityExtension.yaml
@@ -5,10 +5,7 @@ required:
   - valueCodeableConcept
 properties:
   url:
-    type: string
-    enum:
-      - 'https://fhir.nhs.uk/STU3/StructureDefinition/Extension-eRS-ReferralPriority-1'
-    example: 'https://fhir.nhs.uk/STU3/StructureDefinition/Extension-eRS-ReferralPriority-1'
+    $ref: '../fhir/structures/Extension-eRS-ReferralPriority-1.yaml'
   valueCodeableConcept:
     type: object
     required:
@@ -18,7 +15,7 @@ properties:
         type: array
         items:
           type: object
-          required: 
+          required:
             - system
             - code
           properties:

--- a/specification/components/schemas/extensions/ReferralShortlistExtension.yaml
+++ b/specification/components/schemas/extensions/ReferralShortlistExtension.yaml
@@ -5,13 +5,10 @@ required:
   - valueReference
 properties:
   url:
-    type: string
-    enum:
-      - 'https://fhir.nhs.uk/STU3/StructureDefinition/Extension-eRS-ReferralShortlist-1'
-    example: 'https://fhir.nhs.uk/STU3/StructureDefinition/Extension-eRS-ReferralShortlist-1'
+    $ref: '../fhir/structures/Extension-eRS-ReferralShortlist-1.yaml'
   valueReference:
     type: object
-    required: 
+    required:
       - reference
     properties:
       reference:

--- a/specification/components/schemas/extensions/ServiceSummaryViewExtension.yaml
+++ b/specification/components/schemas/extensions/ServiceSummaryViewExtension.yaml
@@ -5,10 +5,7 @@ required:
   - extension
 properties:
   url:
-    type: string
-    enum:
-      - 'https://fhir.nhs.uk/STU3/StructureDefinition/Extension-eRS-ServiceSummaryView-1'
-    example: 'https://fhir.nhs.uk/STU3/StructureDefinition/Extension-eRS-ServiceSummaryView-1'
+    $ref: '../fhir/structures/Extension-eRS-ServiceSummaryView-1.yaml'
   extension:
     type: array
     items:
@@ -36,8 +33,8 @@ properties:
                   items:
                     type: object
                     required:
-                     - system
-                     - code 
+                      - system
+                      - code
                     properties:
                       system:
                         type: string
@@ -46,7 +43,7 @@ properties:
                         example: 'https://fhir.nhs.uk/STU3/CodeSystem/eRS-AppointmentType-1'
                       code:
                         type: string
-                        enum: 
+                        enum:
                           - DAY_CASE
                           - FIRST_OUTPATIENT
                           - ASSESSMENT_SERVICE
@@ -94,8 +91,8 @@ properties:
                   items:
                     type: object
                     required:
-                     - system
-                     - code 
+                      - system
+                      - code
                     properties:
                       system:
                         type: string
@@ -104,7 +101,7 @@ properties:
                         example: 'https://fhir.nhs.uk/STU3/CodeSystem/eRS-RequestFlowType-1'
                       code:
                         type: string
-                        enum: 
+                        enum:
                           - APPOINTMENT_REQUEST
                           - TRIAGE_REQUEST
                           - ADVICE_AND_GUIDANCE_REQUEST
@@ -147,8 +144,8 @@ properties:
                   items:
                     type: object
                     required:
-                     - system
-                     - code 
+                      - system
+                      - code
                     properties:
                       system:
                         type: string
@@ -183,8 +180,8 @@ properties:
                   items:
                     type: object
                     required:
-                     - system
-                     - code 
+                      - system
+                      - code
                     properties:
                       system:
                         type: string
@@ -193,7 +190,7 @@ properties:
                         example: 'https://fhir.nhs.uk/STU3/CodeSystem/eRS-BookableType-1'
                       code:
                         type: string
-                        enum: 
+                        enum:
                           - DIRECTLY_BOOKABLE
                           - INDIRECTLY_BOOKABLE
                           - UNSPECIFIED
@@ -226,7 +223,7 @@ properties:
             valueReference:
               type: object
               required:
-                - identifier 
+                - identifier
                 - display
               properties:
                 identifier:
@@ -304,20 +301,20 @@ properties:
             valueRange:
               type: object
               required:
-                - low 
+                - low
                 - high
               properties:
                 low:
                   type: object
                   required:
                     - value
-                    - unit 
+                    - unit
                   properties:
                     value:
                       type: integer
                       example: 18
                     unit:
-                      type: string 
+                      type: string
                       enum:
                         - YEARS
                         - MONTHS
@@ -332,7 +329,7 @@ properties:
                       type: integer
                       example: 100
                     unit:
-                      type: string 
+                      type: string
                       enum:
                         - YEARS
                         - MONTHS
@@ -360,8 +357,8 @@ properties:
                   items:
                     type: object
                     required:
-                     - system
-                     - code 
+                      - system
+                      - code
                     properties:
                       system:
                         type: string
@@ -370,7 +367,7 @@ properties:
                         example: 'https://fhir.nhs.uk/STU3/CodeSystem/eRS-GenderTreated-1'
                       code:
                         type: string
-                        enum: 
+                        enum:
                           - MALE
                           - FEMALE
                           - MALE_AND_FEMALE
@@ -383,7 +380,7 @@ properties:
           properties:
             url:
               type: string
-              enum: 
+              enum:
                 - additionalRequirementSupported
               example: 'additionalRequirementSupported'
             valueCodeableConcept:
@@ -398,8 +395,8 @@ properties:
                   items:
                     type: object
                     required:
-                     - system
-                     - code 
+                      - system
+                      - code
                     properties:
                       system:
                         type: string
@@ -408,7 +405,7 @@ properties:
                         example: 'https://fhir.nhs.uk/STU3/CodeSystem/eRS-AdditionalRequirementType-1'
                       code:
                         type: string
-                        enum: 
+                        enum:
                           - TRANSPORT
                           - INTERPRETER
                           - ADVOCACY
@@ -473,8 +470,8 @@ properties:
                   items:
                     type: object
                     required:
-                     - system
-                     - code 
+                      - system
+                      - code
                     properties:
                       system:
                         type: string

--- a/specification/components/schemas/fhir/structures/Extension-eRS-Appointment-1.yaml
+++ b/specification/components/schemas/fhir/structures/Extension-eRS-Appointment-1.yaml
@@ -1,0 +1,4 @@
+type: string
+enum:
+  - 'https://fhir.nhs.uk/STU3/StructureDefinition/Extension-eRS-Appointment-1'
+example: 'https://fhir.nhs.uk/STU3/StructureDefinition/Extension-eRS-Appointment-1'

--- a/specification/components/schemas/fhir/structures/Extension-eRS-Commissioning-Rule-Org-1.yaml
+++ b/specification/components/schemas/fhir/structures/Extension-eRS-Commissioning-Rule-Org-1.yaml
@@ -1,0 +1,4 @@
+type: string
+enum:
+  - 'https://fhir.nhs.uk/STU3/StructureDefinition/Extension-eRS-Commissioning-Rule-Org-1'
+example: 'https://fhir.nhs.uk/STU3/StructureDefinition/Extension-eRS-Commissioning-Rule-Org-1'

--- a/specification/components/schemas/fhir/structures/Extension-eRS-EffectivefromDate-1.yaml
+++ b/specification/components/schemas/fhir/structures/Extension-eRS-EffectivefromDate-1.yaml
@@ -1,0 +1,4 @@
+type: string
+enum:
+  - 'https://fhir.nhs.uk/STU3/StructureDefinition/Extension-eRS-EffectivefromDate-1'
+example: 'https://fhir.nhs.uk/STU3/StructureDefinition/Extension-eRS-EffectivefromDate-1'

--- a/specification/components/schemas/fhir/structures/Extension-eRS-EffectivetoDate-1.yaml
+++ b/specification/components/schemas/fhir/structures/Extension-eRS-EffectivetoDate-1.yaml
@@ -1,0 +1,4 @@
+type: string
+enum:
+  - 'https://fhir.nhs.uk/STU3/StructureDefinition/Extension-eRS-EffectivetoDate-1'
+example: 'https://fhir.nhs.uk/STU3/StructureDefinition/Extension-eRS-EffectivetoDate-1'

--- a/specification/components/schemas/fhir/structures/Extension-eRS-ReferralPriority-1.yaml
+++ b/specification/components/schemas/fhir/structures/Extension-eRS-ReferralPriority-1.yaml
@@ -1,0 +1,4 @@
+type: string
+enum:
+  - 'https://fhir.nhs.uk/STU3/StructureDefinition/Extension-eRS-ReferralPriority-1'
+example: 'https://fhir.nhs.uk/STU3/StructureDefinition/Extension-eRS-ReferralPriority-1'

--- a/specification/components/schemas/fhir/structures/Extension-eRS-ReferralShortlist-1.yaml
+++ b/specification/components/schemas/fhir/structures/Extension-eRS-ReferralShortlist-1.yaml
@@ -1,0 +1,4 @@
+type: string
+enum:
+  - 'https://fhir.nhs.uk/STU3/StructureDefinition/Extension-eRS-ReferralShortlist-1'
+example: 'https://fhir.nhs.uk/STU3/StructureDefinition/Extension-eRS-ReferralShortlist-1'

--- a/specification/components/schemas/fhir/structures/Extension-eRS-ServiceSearch-ListItem-1.yaml
+++ b/specification/components/schemas/fhir/structures/Extension-eRS-ServiceSearch-ListItem-1.yaml
@@ -1,0 +1,4 @@
+type: string
+enum:
+  - https://fhir.nhs.uk/STU3/StructureDefinition/Extension-eRS-ServiceSearch-ListItem-1
+example: 'https://fhir.nhs.uk/STU3/StructureDefinition/Extension-eRS-ServiceSearch-ListItem-1'

--- a/specification/components/schemas/fhir/structures/Extension-eRS-ServiceSummaryView-1.yaml
+++ b/specification/components/schemas/fhir/structures/Extension-eRS-ServiceSummaryView-1.yaml
@@ -1,0 +1,4 @@
+type: string
+enum:
+  - 'https://fhir.nhs.uk/STU3/StructureDefinition/Extension-eRS-ServiceSummaryView-1'
+example: 'https://fhir.nhs.uk/STU3/StructureDefinition/Extension-eRS-ServiceSummaryView-1'

--- a/specification/components/schemas/fhir/structures/eRS-CreateReferral-Parameters-1.yaml
+++ b/specification/components/schemas/fhir/structures/eRS-CreateReferral-Parameters-1.yaml
@@ -1,0 +1,4 @@
+type: string
+enum:
+  - "https://fhir.nhs.uk/STU3/StructureDefinition/eRS-CreateReferral-Parameters-1"
+example: "https://fhir.nhs.uk/STU3/StructureDefinition/eRS-CreateReferral-Parameters-1"

--- a/specification/components/schemas/fhir/structures/eRS-CreateReferralAndSendForTriage-Parameters-1.yaml
+++ b/specification/components/schemas/fhir/structures/eRS-CreateReferralAndSendForTriage-Parameters-1.yaml
@@ -1,0 +1,4 @@
+type: string
+enum:
+  - 'https://fhir.nhs.uk/STU3/StructureDefinition/eRS-CreateReferralAndSendForTriage-Parameters-1'
+example: 'https://fhir.nhs.uk/STU3/StructureDefinition/eRS-CreateReferralAndSendForTriage-Parameters-1'

--- a/specification/components/schemas/fhir/structures/eRS-FetchServices-List-1.yaml
+++ b/specification/components/schemas/fhir/structures/eRS-FetchServices-List-1.yaml
@@ -1,0 +1,4 @@
+type: string
+enum:
+  - 'https://fhir.nhs.uk/STU3/StructureDefinition/eRS-FetchServices-List-1'
+example: 'https://fhir.nhs.uk/STU3/StructureDefinition/eRS-FetchServices-List-1'

--- a/specification/components/schemas/fhir/structures/eRS-OperationOutcome-1.yaml
+++ b/specification/components/schemas/fhir/structures/eRS-OperationOutcome-1.yaml
@@ -1,0 +1,4 @@
+type: string
+enum:
+  - 'https://fhir.nhs.uk/STU3/StructureDefinition/eRS-OperationOutcome-1'
+example: 'https://fhir.nhs.uk/STU3/StructureDefinition/eRS-OperationOutcome-1'

--- a/specification/components/schemas/fhir/structures/eRS-PatientServiceSearch-Parameters-1.yaml
+++ b/specification/components/schemas/fhir/structures/eRS-PatientServiceSearch-Parameters-1.yaml
@@ -1,0 +1,4 @@
+type: string
+enum:
+  - 'https://fhir.nhs.uk/STU3/StructureDefinition/eRS-PatientServiceSearch-Parameters-1'
+example: 'https://fhir.nhs.uk/STU3/StructureDefinition/eRS-PatientServiceSearch-Parameters-1'

--- a/specification/components/schemas/fhir/structures/eRS-ReferralRequest-1.yaml
+++ b/specification/components/schemas/fhir/structures/eRS-ReferralRequest-1.yaml
@@ -1,0 +1,4 @@
+type: string
+enum:
+  - 'https://fhir.nhs.uk/STU3/StructureDefinition/eRS-ReferralRequest-1'
+example: 'https://fhir.nhs.uk/STU3/StructureDefinition/eRS-ReferralRequest-1'

--- a/specification/components/schemas/fhir/structures/eRS-ServiceSearchCriteria-Parameters-1.yaml
+++ b/specification/components/schemas/fhir/structures/eRS-ServiceSearchCriteria-Parameters-1.yaml
@@ -1,0 +1,4 @@
+type: string
+enum:
+  - 'https://fhir.nhs.uk/STU3/StructureDefinition/eRS-ServiceSearchCriteria-Parameters-1'
+example: 'https://fhir.nhs.uk/STU3/StructureDefinition/eRS-ServiceSearchCriteria-Parameters-1'

--- a/specification/components/schemas/fhir/structures/eRS-Shortlist-List-1.yaml
+++ b/specification/components/schemas/fhir/structures/eRS-Shortlist-List-1.yaml
@@ -1,0 +1,4 @@
+type: string
+enum:
+  - 'https://fhir.nhs.uk/STU3/StructureDefinition/eRS-Shortlist-List-1'
+example: 'https://fhir.nhs.uk/STU3/StructureDefinition/eRS-Shortlist-List-1'


### PR DESCRIPTION
To reduce "noise" in the specifications, move definitions such as this:

```
type: string
enum:
  - 'https://fhir.nhs.uk/STU3/StructureDefinition/eRS-FetchServices-List-1'
example: 'https://fhir.nhs.uk/STU3/StructureDefinition/eRS-FetchServices-List-1'
```

out of the top-level yaml files, into `specification/components/schemas/fhir/structures/eRS-FetchServices-List-1.yaml`



