### PR TITLE
APM-2786 Update prod stage_name to fix grafana monitoring

### DIFF
--- a/azure/azure-release-pipeline.yml
+++ b/azure/azure-release-pipeline.yml
@@ -89,7 +89,7 @@ extends:
       depends_on:
       - manual_approval_int
     - environment: prod
-      stage_name: ers_prod_release
+      stage_name: prod #revert to ers_prod_release when monitoring stack fixed to support it.
       post_deploy:
       - template: templates/ers-smoke.yml
       depends_on:


### PR DESCRIPTION
## Summary
* :robot: Operational or Infrastructure Change

This is a temporary change to fix the grafana dashboard for e-RS in prod. Long term we will fix the monitoring stack to allow for different stage names but for now this should be done so grafana monitor e-RS in production


## Reviews Required
* [x] Dev
* [ ] Test
* [ ] Tech Author
* [ ] Product Owner
