### PR TITLE
APM-3466 Remove ref env and disable status monitoring on fix env

### DIFF
--- a/azure/azure-release-pipeline.yml
+++ b/azure/azure-release-pipeline.yml
@@ -83,6 +83,7 @@ extends:
       service_name: "${{ variables.service_name }}-fix"
       short_service_name: "${{ variables.short_service_name }}-fix"
       service_base_path: "${{ variables.service_base_path }}-fix"
+      enable_status_monitoring: false
       jinja_templates:
         ERS_TARGET_SERVER: e-referrals-service-api--fix
         ALLOW_ECHO_TARGET: true
@@ -121,16 +122,6 @@ extends:
           smoke_tests: true
       depends_on:
       - ers_sa_release
-    - environment: manual-approval
-      stage_name: manual_approval_nft2
-    - environment: ref
-      stage_name: ers_nft2_release
-      post_deploy:
-      - template: templates/run-tests.yml
-        parameters:
-          smoke_tests: true
-      depends_on:
-      - manual_approval_nft2
     - environment: internal-qa-sandbox
       proxy_path: sandbox
       depends_on:

--- a/manifest_template.yml
+++ b/manifest_template.yml
@@ -16,8 +16,6 @@ APIGEE_ENVIRONMENTS:
   name: internal-qa
 - display_name: Internal QA Sandbox
   name: internal-qa-sandbox
-- display_name: Reference
-  name: ref
 - display_name: Sandbox
   name: sandbox
 - name: prod


### PR DESCRIPTION
Remove unused Ref env from environment list and disable status monitoring for the fix-env which does not always have a live backend
https://nhsd-jira.digital.nhs.uk/browse/APM-3466  